### PR TITLE
fix: monitor rework steps visibility, per-step logs, and quality gate…

### DIFF
--- a/monitor/public-v3/styles.css
+++ b/monitor/public-v3/styles.css
@@ -1205,6 +1205,22 @@ input[type="text"]:focus {
   border-color: color-mix(in srgb, var(--err), white 60%);
 }
 
+.feed-card.rework-step {
+  border-color: color-mix(in srgb, var(--warn), white 55%);
+  border-left: 3px solid var(--warn);
+}
+
+.rework-label {
+  font-size: 11px;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--warn), var(--text) 40%);
+  background: color-mix(in srgb, var(--warn), white 85%);
+  border: 1px solid color-mix(in srgb, var(--warn), white 55%);
+  border-radius: 999px;
+  padding: 1px 8px;
+  white-space: nowrap;
+}
+
 .feed-card.completed {
   border-color: color-mix(in srgb, var(--ok), white 70%);
 }
@@ -1317,6 +1333,41 @@ input[type="text"]:focus {
 }
 
 /* Step timeline events (inline per card) */
+.feed-alert {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 9px 12px;
+  border-radius: 6px;
+  font-size: 13px;
+  line-height: 1.45;
+  margin: 10px 0 2px;
+}
+
+.feed-alert--token {
+  background: color-mix(in srgb, var(--err), white 88%);
+  border-left: 3px solid var(--err);
+  color: color-mix(in srgb, var(--err), var(--text) 50%);
+}
+
+.feed-alert--rework {
+  background: color-mix(in srgb, var(--warn), white 88%);
+  border-left: 3px solid var(--warn);
+  color: color-mix(in srgb, var(--warn), var(--text) 50%);
+}
+
+.feed-alert-icon {
+  font-style: normal;
+  flex-shrink: 0;
+  line-height: 1.45;
+}
+
+.pill--rework {
+  background: color-mix(in srgb, var(--warn), white 80%);
+  border-color: color-mix(in srgb, var(--warn), white 50%);
+  color: color-mix(in srgb, var(--warn), var(--text) 60%);
+}
+
 .feed-events {
   margin-top: 10px;
   padding-top: 8px;

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "dev": "tsx src/index.ts",
     "monitor": "node monitor/server.mjs",
     "start": "node dist/index.js",
+    "lint": "tsc --noEmit",
+    "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
     "typecheck:tests": "tsc --noEmit -p tsconfig.tests.json",
     "test": "vitest run",

--- a/src/service/runtime/codex-planner-runtime.ts
+++ b/src/service/runtime/codex-planner-runtime.ts
@@ -54,6 +54,7 @@ Set "model" for each step to the agent model that should run that step.`;
     const apiKey = this.resolveOpenAiKey(runtime.mode);
     const runtimeArgs = runtime.args ?? [];
     const hasSandboxFlag = runtimeArgs.includes("--sandbox") || runtimeArgs.includes("-s");
+    const hasBypassFlag = runtimeArgs.includes("--dangerously-bypass-approvals-and-sandbox");
     await runProcess(runtime.command ?? "codex", [
       ...runtimeArgs,
       "exec",
@@ -61,7 +62,7 @@ Set "model" for each step to the agent model that should run that step.`;
       "--json",
       "--output-last-message",
       ".planner-plan.raw.txt",
-      ...(hasSandboxFlag ? [] : ["--sandbox", "workspace-write"]),
+      ...(hasSandboxFlag || hasBypassFlag ? [] : ["--sandbox", "workspace-write"]),
     ], {
       cwd: workspacePath,
       env: {

--- a/src/service/runtime/codex-runtime.ts
+++ b/src/service/runtime/codex-runtime.ts
@@ -24,7 +24,13 @@ export class CodexRuntime implements AgentRuntime {
     ].join("\n");
     const runtimeArgs = config.runtime.args ?? [];
     const hasSandboxFlag = runtimeArgs.includes("--sandbox") || runtimeArgs.includes("-s");
-    const args = ["exec", prompt, "--json", ...(hasSandboxFlag ? [] : ["--sandbox", "workspace-write"])];
+    const hasBypassFlag = runtimeArgs.includes("--dangerously-bypass-approvals-and-sandbox");
+    const args = [
+      "exec",
+      prompt,
+      "--json",
+      ...(hasSandboxFlag || hasBypassFlag ? [] : ["--sandbox", "workspace-write"]),
+    ];
     const env = {
       ...process.env,
       ...(config.apiKey ? { OPENAI_API_KEY: config.apiKey } : {}),
@@ -54,6 +60,7 @@ export class CodexRuntime implements AgentRuntime {
       runtime_mode: config.runtime.mode,
       runtime_args: runtimeArgs,
       has_sandbox_flag: hasSandboxFlag,
+      has_bypass_flag: hasBypassFlag,
       openai_model: env.OPENAI_MODEL ?? "",
       openai_api_key_present: Boolean(env.OPENAI_API_KEY),
       codex_home: env.CODEX_HOME ?? "",


### PR DESCRIPTION
… resilience

Monitor:
- Rework steps (900+) now visible in run detail — materialise them from step.started/completed events since they are not in the original plan
- Token-limit and rework-triggered alerts rendered as prominent banners inside each step card, with amber header pill for rework count
- Per-step log serving: /api/log now accepts ?step=N, reads .{claude|codex}-runtime.step-N.attempt-M.{stdout,stderr}.log directly instead of the overwritten "latest" file
- Client fetches logs per step with caching for completed steps; step summary extracted from step.completed event so rework steps show output
- Auto-refresh no longer resets scroll position or collapses open sections
- Stable log block IDs (content hash instead of positional index)
- monitor/server.mjs supports --port CLI flag

Quality gates (developer agent):
- Add npm run lint script (tsc --noEmit) to package.json
- Agent instructions now use --if-present for all four checks so missing scripts are skipped (not looped on); pnpm/yarn fallback covers all four
- Install dependencies before running checks if node_modules is missing