### PR TITLE
Fix resume session persistence and PR creation robustness

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@anthropic-ai/mcp-server-playwright"]
+    }
+  }
+}

--- a/config/project-sprintfoundry-claude-all-sonnet46.yaml
+++ b/config/project-sprintfoundry-claude-all-sonnet46.yaml
@@ -1,0 +1,114 @@
+# SprintFoundry — Project Configuration
+# All platform agents + planner run on Claude Sonnet 4.6
+
+project_id: sprintfoundry-claude-all-sonnet46
+name: SprintFoundry (Claude All Agents Sonnet 4.6)
+
+stack: js
+
+agents:
+  - product
+  - architect
+  - developer
+  - go-developer
+  - code-review
+  - qa
+  - go-qa
+  - security
+  - ui-ux
+  - devops
+
+repo:
+  url: git@github.com:Sagart-cactus/SprintFoundry.git
+  default_branch: main
+
+api_keys:
+  anthropic: ${SPRINTFOUNDRY_ANTHROPIC_KEY}
+
+model_overrides:
+  product:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  architect:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  developer:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  go-developer:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  code-review:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  qa:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  go-qa:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  security:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  ui-ux:
+    provider: anthropic
+    model: claude-sonnet-4-6
+  devops:
+    provider: anthropic
+    model: claude-sonnet-4-6
+
+runtime_overrides:
+  product:
+    provider: claude-code
+    mode: local_process
+  architect:
+    provider: claude-code
+    mode: local_process
+  developer:
+    provider: claude-code
+    mode: local_process
+  go-developer:
+    provider: claude-code
+    mode: local_process
+  code-review:
+    provider: claude-code
+    mode: local_process
+  qa:
+    provider: claude-code
+    mode: local_process
+  go-qa:
+    provider: claude-code
+    mode: local_process
+  security:
+    provider: claude-code
+    mode: local_process
+  ui-ux:
+    provider: claude-code
+    mode: local_process
+  devops:
+    provider: claude-code
+    mode: local_process
+
+planner_runtime_override:
+  provider: claude-code
+  mode: local_process
+
+budget_overrides:
+  per_agent_tokens: 1000000
+  per_task_total_tokens: 6000000
+  per_task_max_cost_usd: 60.00
+
+branch_strategy:
+  prefix: feat/
+  include_ticket_id: true
+  naming: kebab-case
+
+integrations:
+  ticket_source:
+    type: github
+    config:
+      token: ${GITHUB_TOKEN}
+      owner: Sagart-cactus
+      repo: SprintFoundry
+
+rules: []

--- a/config/project-sprintfoundry-codex-all.yaml
+++ b/config/project-sprintfoundry-codex-all.yaml
@@ -1,0 +1,152 @@
+# SprintFoundry — Project Configuration
+# All platform agents + planner run on Codex
+
+project_id: sprintfoundry-codex-all
+name: SprintFoundry (Codex All Agents)
+
+stack: js
+
+agents:
+  - product
+  - architect
+  - developer
+  - go-developer
+  - code-review
+  - qa
+  - go-qa
+  - security
+  - ui-ux
+  - devops
+
+repo:
+  url: git@github.com:Sagart-cactus/SprintFoundry.git
+  default_branch: main
+
+api_keys:
+  openai: ${SPRINTFOUNDRY_OPENAI_KEY}
+
+model_overrides:
+  orchestrator:
+    provider: openai
+    model: gpt-5.3-codex
+  product:
+    provider: openai
+    model: gpt-5.3-codex
+  architect:
+    provider: openai
+    model: gpt-5.3-codex
+  developer:
+    provider: openai
+    model: gpt-5.3-codex
+  go-developer:
+    provider: openai
+    model: gpt-5.3-codex
+  code-review:
+    provider: openai
+    model: gpt-5.3-codex
+  qa:
+    provider: openai
+    model: gpt-5.3-codex
+  go-qa:
+    provider: openai
+    model: gpt-5.3-codex
+  security:
+    provider: openai
+    model: gpt-5.3-codex
+  ui-ux:
+    provider: openai
+    model: gpt-5.3-codex
+  devops:
+    provider: openai
+    model: gpt-5.3-codex
+
+runtime_overrides:
+  product:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  architect:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  developer:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  go-developer:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  code-review:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  qa:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  go-qa:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  security:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  ui-ux:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+  devops:
+    provider: codex
+    mode: local_process
+    model_reasoning_effort: medium
+    args:
+      - --dangerously-bypass-approvals-and-sandbox
+
+planner_runtime_override:
+  provider: codex
+  mode: local_process
+  model_reasoning_effort: high
+  args:
+    - --model
+    - gpt-5.3-codex
+    - --dangerously-bypass-approvals-and-sandbox
+
+budget_overrides:
+  per_agent_tokens: 1000000
+  per_task_total_tokens: 6000000
+  per_task_max_cost_usd: 60.00
+
+branch_strategy:
+  prefix: feat/
+  include_ticket_id: true
+  naming: kebab-case
+
+integrations:
+  ticket_source:
+    type: github
+    config:
+      token: ${GITHUB_TOKEN}
+      owner: Sagart-cactus
+      repo: SprintFoundry
+
+rules: []

--- a/spike/codex-sdk-poc-output.json
+++ b/spike/codex-sdk-poc-output.json
@@ -1,7 +1,7 @@
 {
   "sdkVersion": "0.104.0",
   "mode": "preflight",
-  "model": "gpt-5.3-codex",
+  "model": "gpt-5",
   "workspacePath": "(not created)",
   "checks": [
     {


### PR DESCRIPTION
## Summary
- parse Codex CLI `thread.started.thread_id` in `local_process` runs and use it as runtime/session id
- keep Claude behavior unchanged while enabling real session persistence for Codex resume paths
- sanitize branch name ticket segments (e.g. `#21` -> `21`) to avoid invalid/inference issues
- make PR creation explicit with `--head <owner>:<branch>` to avoid branch-tracking inference failures
- add/adjust tests for runtime id parsing, branch sanitization, and explicit PR head behavior

## Validation
- npm test -- tests/process-utils.test.ts
- npm test -- tests/codex-runtime-sdk.test.ts
- npm test -- tests/orchestration-service.test.ts -t "resumed rework|resume fallback telemetry"
- npm test -- tests/git-manager.test.ts
