### PR TITLE
Revamp run monitor details UI + fix per-step result overwrite

### DIFF
--- a/monitor/public-v3/run.html
+++ b/monitor/public-v3/run.html
@@ -37,6 +37,18 @@
       <main class="run-feed" id="run-feed"></main>
     </div>
 
+    <div class="detail-drawer-backdrop" id="detail-drawer-backdrop" hidden></div>
+    <aside class="detail-drawer" id="detail-drawer" aria-hidden="true">
+      <header class="detail-drawer-header">
+        <div>
+          <div class="detail-drawer-kicker" id="detail-drawer-kicker">Step details</div>
+          <h2 id="detail-drawer-title">Details</h2>
+        </div>
+        <button id="detail-drawer-close" type="button" aria-label="Close detail drawer">Close</button>
+      </header>
+      <div class="detail-drawer-body" id="detail-drawer-body"></div>
+    </aside>
+
     <footer class="statusbar">
       <span id="status-line">Loading run...</span>
       <span id="last-refreshed">Last refreshed: -</span>

--- a/monitor/public-v3/styles.css
+++ b/monitor/public-v3/styles.css
@@ -1387,6 +1387,27 @@ input[type="text"]:focus {
   overflow: auto;
 }
 
+.feed-actions {
+  margin-top: 10px;
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.feed-action-btn {
+  height: 32px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: 1px solid #c8d9ea;
+  background: #eef5ff;
+  color: #123a66;
+}
+
+.feed-action-btn:hover {
+  background: #deebff;
+}
+
 /* Step timeline events (inline per card) */
 .feed-alert {
   display: flex;
@@ -1452,6 +1473,106 @@ input[type="text"]:focus {
   color: var(--muted);
 }
 
+.detail-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 32, 0.35);
+  z-index: 60;
+}
+
+.detail-drawer {
+  position: fixed;
+  top: 66px;
+  right: 0;
+  width: min(560px, 94vw);
+  height: calc(100vh - 108px);
+  border-left: 1px solid var(--line);
+  background: var(--surface);
+  box-shadow: -16px 0 40px rgba(15, 23, 32, 0.22);
+  z-index: 70;
+  transform: translateX(100%);
+  transition: transform 0.18s ease-out;
+  display: flex;
+  flex-direction: column;
+}
+
+.detail-drawer.open {
+  transform: translateX(0);
+}
+
+.detail-drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 12px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.detail-drawer-kicker {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+}
+
+.detail-drawer-header h2 {
+  margin: 4px 0 0;
+  font-size: 1rem;
+  line-height: 1.3;
+}
+
+.detail-drawer-body {
+  padding: 14px 16px 16px;
+  overflow: auto;
+  display: grid;
+  gap: 12px;
+}
+
+.drawer-section {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: var(--surface-soft);
+  padding: 10px;
+}
+
+.drawer-section h3 {
+  margin: 0 0 8px;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--muted);
+}
+
+.result-grid {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 6px 10px;
+  font-size: 0.8125rem;
+}
+
+.result-key {
+  color: var(--muted);
+}
+
+.result-value {
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.result-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 4px;
+}
+
+.result-list code {
+  font-family: "IBM Plex Mono", "SFMono-Regular", Consolas, monospace;
+  font-size: 0.75rem;
+}
+
 /* Responsive: stack sidebar below on small screens */
 @media (max-width: 768px) {
   .run-layout {
@@ -1467,5 +1588,12 @@ input[type="text"]:focus {
 
   .run-feed {
     padding: 12px;
+  }
+
+  .detail-drawer {
+    top: 0;
+    height: calc(100vh - 46px);
+    width: 100vw;
+    max-width: 100vw;
   }
 }

--- a/src/service/agent-runner.ts
+++ b/src/service/agent-runner.ts
@@ -138,6 +138,13 @@ export class AgentRunner {
         token_savings: result.token_savings,
       },
     };
+    await this.persistStepResultSnapshot(
+      config.workspacePath,
+      config.stepNumber,
+      config.stepAttempt,
+      config.agent,
+      agentResult
+    );
 
     const duration = (Date.now() - startTime) / 1000;
     const costUsd =
@@ -589,6 +596,23 @@ export class AgentRunner {
         metadata: {},
       };
     }
+  }
+
+  private async persistStepResultSnapshot(
+    workspacePath: string,
+    stepNumber: number,
+    stepAttempt: number,
+    agent: AgentType,
+    result: AgentResult
+  ): Promise<void> {
+    const dir = path.join(workspacePath, ".sprintfoundry", "step-results");
+    await fs.mkdir(dir, { recursive: true });
+    const safeAgent = agent.replace(/[^a-z0-9_-]/gi, "-");
+    const filePath = path.join(
+      dir,
+      `step-${stepNumber}.attempt-${stepAttempt}.${safeAgent}.json`
+    );
+    await fs.writeFile(filePath, JSON.stringify(result, null, 2), "utf-8");
   }
 
   // ---- Utilities ----

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -225,6 +225,30 @@ describe("AgentRunner", () => {
     expect(parsed.issues).toContain("Missing required fields in .agent-result.json");
   });
 
+  it("persistStepResultSnapshot writes per-step result file", async () => {
+    const workspacePath = path.join(tmpDir, "workspace-step-snapshot");
+    await fs.mkdir(workspacePath, { recursive: true });
+    const runner = new AgentRunner(makePlatformConfig(), makeProjectConfig());
+
+    await (runner as any).persistStepResultSnapshot(
+      workspacePath,
+      7,
+      2,
+      "code-review",
+      makeResult({ summary: "Snapshot saved" })
+    );
+
+    const snapshotPath = path.join(
+      workspacePath,
+      ".sprintfoundry",
+      "step-results",
+      "step-7.attempt-2.code-review.json"
+    );
+    const raw = await fs.readFile(snapshotPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    expect(parsed.summary).toBe("Snapshot saved");
+  });
+
   it("parseTokenUsage extracts from JSON output", () => {
     const runner = new AgentRunner(makePlatformConfig(), makeProjectConfig());
     const output = JSON.stringify({ usage: { total_tokens: 1234 } });

--- a/tests/api/monitor-routes.test.ts
+++ b/tests/api/monitor-routes.test.ts
@@ -168,3 +168,11 @@ describe("GET /api/files", () => {
     expect(JSON.parse(body)).toHaveProperty("error");
   });
 });
+
+describe("GET /api/step-result", () => {
+  it("returns 400 when project/run/step params are missing", async () => {
+    const { status, body } = await get(`${BASE}/api/step-result`);
+    expect(status).toBe(400);
+    expect(JSON.parse(body)).toHaveProperty("error");
+  });
+});


### PR DESCRIPTION
## Summary
- add a right-side detail drawer for step-level inspection
- move Agent Output and step Result details into drawer actions from each step card
- replace raw Result JSON view with parsed sections (status, summary, artifacts created, files modified, issues, metadata)
- show file diffs for artifacts in the drawer via existing `/api/diff` endpoint
- fix monitor bug where all steps showed the last executed `.agent-result.json` payload

## Technical changes
- `monitor/public-v3/run.html`
  - adds detail drawer shell and backdrop
- `monitor/public-v3/styles.css`
  - drawer/layout/action button styling
- `monitor/public-v3/run.js`
  - drawer state + interactions
  - per-step result loading via new API
  - removes global agent-result fallback binding from step cards
- `monitor/server.mjs`
  - adds `/api/step-result`
  - resolves per-step results from `.sprintfoundry/step-results` and `.agent-context`
  - only uses `.agent-result.json` as fallback for latest completed step
- `src/service/agent-runner.ts`
  - persists per-step snapshots to `.sprintfoundry/step-results/step-<n>.attempt-<m>.<agent>.json`

## Tests
- `npm test -- tests/api/monitor-routes.test.ts`
- `npm test -- tests/agent-runner.test.ts`

