### PR TITLE
fix(doctor): don't require OpenAI key for codex local_process mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -265,7 +265,7 @@ program
         if (rt.mode === "container") needsDocker = true;
       } else if (rt.provider === "codex") {
         if (rt.mode === "local_process") needsCodexCli = true;
-        if (rt.mode === "local_process" || rt.mode === "local_sdk") needsOpenaiKey = true;
+        if (rt.mode === "local_sdk") needsOpenaiKey = true;
       }
     };
 


### PR DESCRIPTION
Addresses the P2 review comment from `chatgpt-codex-connector[bot]` on PR #51.

## Problem

`sprintfoundry doctor` was marking the OpenAI API key as required whenever any agent used `codex` + `local_process` runtime. This caused a hard failure and non-zero exit on setups that rely on Codex CLI auth — even though `local_process` authenticates via the CLI, not via an API key.

The same issue doesn't exist for `claude-code`: that branch only requires the Anthropic key for `local_sdk` and `container` modes, never `local_process`.

## Fix

Remove `local_process` from the `needsOpenaiKey` check. Only `local_sdk` requires `OPENAI_API_KEY`.

```diff
- if (rt.mode === "local_process" || rt.mode === "local_sdk") needsOpenaiKey = true;
+ if (rt.mode === "local_sdk") needsOpenaiKey = true;
```

## Test plan

- [ ] Run `sprintfoundry doctor` with a project config using `codex` + `local_process` and no `OPENAI_API_KEY` set — should pass
- [ ] Run with `codex` + `local_sdk` and no key — should still fail with a clear message
- [ ] Run with `codex` + `local_process` and key set — should pass with "set" detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)