### PR TITLE
Add Linear label-driven runtime skill injection

### DIFF
--- a/config/project.example.yaml
+++ b/config/project.example.yaml
@@ -105,6 +105,26 @@ api_keys:
 # #     path: vendor/codex-skills/web-design-guidelines
 # # codex_skills_overrides:
 # #   ui-ux: [web-design-guidelines]
+#
+# # Explicit ticket-label skill injection (additive only)
+# # Use labels like:
+# #   sf:skill:develop-web-game
+# #   sf:skill:phaser-arcade-platformer
+# # dynamic_skills:
+# #   enabled: true
+# #   label_source: linear
+# #   label_prefix: "sf:skill:"
+# #   allow_ticket_labels: true
+# #   allowlist:
+# #     - develop-web-game
+# #     - playwright
+# #     - phaser-arcade-platformer
+# #   agent_allowlist:
+# #     developer:
+# #       - develop-web-game
+# #       - phaser-arcade-platformer
+# #     qa:
+# #       - playwright
 
 # ----- Workspace Strategy (optional) -----
 # Override the platform default workspace strategy.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -225,6 +225,47 @@ codex_skills_overrides:
     - error-handling
 ```
 
+#### `dynamic_skills`
+Allow explicit ticket labels to add runtime skills for a run.
+
+This feature is additive:
+
+- base per-agent skills still apply
+- ticket labels can add more allowed skills
+- labels cannot remove base skills
+
+Recommended label format:
+
+- `sf:skill:develop-web-game`
+- `sf:skill:playwright`
+
+```yaml
+dynamic_skills:
+  enabled: true
+  label_source: linear          # linear | all
+  label_prefix: "sf:skill:"
+  allow_ticket_labels: true
+  allowlist:
+    - develop-web-game
+    - playwright
+    - phaser-arcade-platformer
+  denylist:
+    - internal-only-skill
+  agent_allowlist:
+    developer:
+      - develop-web-game
+      - phaser-arcade-platformer
+    qa:
+      - playwright
+```
+
+Behavior:
+
+- only labels with the configured prefix are considered
+- unknown or disallowed skills are ignored with warnings
+- if `agent_allowlist` is configured, only listed agents may receive listed skills
+- staged runtime metadata records base skills, label skills, ignored labels, and rejected skills
+
 ---
 
 ## Platform Config (`platform.yaml`)
@@ -510,6 +551,22 @@ guardrails:
     - "public/**"
 
 codex_skills_enabled: false
+
+dynamic_skills:
+  enabled: true
+  label_source: linear
+  label_prefix: "sf:skill:"
+  allow_ticket_labels: true
+  allowlist:
+    - develop-web-game
+    - playwright
+    - phaser-arcade-platformer
+  agent_allowlist:
+    developer:
+      - develop-web-game
+      - phaser-arcade-platformer
+    qa:
+      - playwright
 
 branch_strategy:
   prefix: feat/

--- a/src/service/agent-runner.ts
+++ b/src/service/agent-runner.ts
@@ -18,9 +18,11 @@ import type {
   ProjectConfig,
   RuntimeConfig,
   RuntimeMetadataEnvelope,
+  TicketDetails,
 } from "../shared/types.js";
 import { RuntimeFactory } from "./runtime/runtime-factory.js";
 import { CodexSkillManager } from "./runtime/codex-skill-manager.js";
+import { DynamicSkillResolver } from "./runtime/dynamic-skill-resolver.js";
 import type { RuntimeActivityEvent } from "./runtime/types.js";
 import type { EventSinkClient } from "./event-sink-client.js";
 import { resolveHostingMode } from "./hosting-mode.js";
@@ -37,6 +39,7 @@ export interface AgentRunConfig {
   stepAttempt: number;
   agent: AgentType;
   task: string;
+  ticket?: TicketDetails;
   context_inputs: ContextInput[];
   workspacePath: string;
   modelConfig: ModelConfig;
@@ -71,6 +74,11 @@ interface WorkspacePrepResult {
   runtimeSkillsDir?: string;
   skillWarnings?: string[];
   skillHashes?: Record<string, string>;
+  baseSkillNames?: string[];
+  labelSkillNames?: string[];
+  ignoredDynamicSkillLabels?: string[];
+  rejectedDynamicSkills?: Array<{ skill: string; reason: string }>;
+  skillResolutionMode?: "static" | "dynamic_label_merge";
 }
 
 export interface AgentRunResult {
@@ -92,6 +100,7 @@ export class AgentRunner {
   private codexAgentDir: string;
   private projectRoot: string;
   private codexSkillManager: CodexSkillManager;
+  private dynamicSkillResolver: DynamicSkillResolver;
   private executionBackend: ExecutionBackend;
 
   constructor(
@@ -108,6 +117,11 @@ export class AgentRunner {
       platformConfig,
       projectConfig,
       this.projectRoot
+    );
+    this.dynamicSkillResolver = new DynamicSkillResolver(
+      platformConfig,
+      projectConfig,
+      this.codexSkillManager
     );
     this.executionBackend = executionBackend ?? new LocalExecutionBackend();
   }
@@ -263,20 +277,34 @@ export class AgentRunner {
     await fs.mkdir(path.join(workspacePath, "artifacts"), { recursive: true });
     await fs.mkdir(path.join(workspacePath, "artifacts", "handoff"), { recursive: true });
 
-    const resolved = this.codexSkillManager.resolveForAgent(
-      config.agent,
-      runtime.provider
-    );
-    if (!resolved.enabled) {
+    const resolved = await this.dynamicSkillResolver.resolveForRun({
+      agent: config.agent,
+      runtimeProvider: runtime.provider,
+      ticket: config.ticket,
+      workspacePath,
+    });
+    if (!resolved.enabled && resolved.warnings.length === 0) {
       return {};
     }
     for (const warning of resolved.warnings) {
       console.warn(`[agent-runner] Skill guardrail warning: ${warning}`);
     }
 
+    if (resolved.finalSkillNames.length === 0) {
+      return {
+        runtimeSkillProvider: runtime.provider,
+        skillWarnings: [...resolved.warnings],
+        baseSkillNames: resolved.baseSkillNames,
+        labelSkillNames: resolved.labelSkillNames,
+        ignoredDynamicSkillLabels: resolved.ignoredLabels,
+        rejectedDynamicSkills: resolved.rejectedSkills,
+        skillResolutionMode: resolved.resolutionMode,
+      };
+    }
+
     const staged = await this.codexSkillManager.stageSkills(
       workspacePath,
-      resolved.skillNames,
+      resolved.finalSkillNames,
       runtime.provider
     );
     for (const warning of staged.warnings) {
@@ -294,6 +322,11 @@ export class AgentRunner {
       runtimeSkillsDir: staged.skillsDir,
       skillWarnings: [...resolved.warnings, ...staged.warnings],
       skillHashes: staged.skillHashes,
+      baseSkillNames: resolved.baseSkillNames,
+      labelSkillNames: resolved.labelSkillNames,
+      ignoredDynamicSkillLabels: resolved.ignoredLabels,
+      rejectedDynamicSkills: resolved.rejectedSkills,
+      skillResolutionMode: resolved.resolutionMode,
     };
   }
 
@@ -334,6 +367,11 @@ export class AgentRunner {
         ...(base.provider_metadata ?? {}),
         skills: {
           names: prep.codexSkillNames ?? [],
+          base_skills: prep.baseSkillNames ?? [],
+          label_skills: prep.labelSkillNames ?? [],
+          ignored_labels: prep.ignoredDynamicSkillLabels ?? [],
+          rejected_skills: prep.rejectedDynamicSkills ?? [],
+          resolution_mode: prep.skillResolutionMode ?? "static",
           provider: prep.runtimeSkillProvider ?? "codex",
           skills_dir: prep.runtimeSkillsDir,
           warnings: prep.skillWarnings ?? [],

--- a/src/service/orchestration-service.ts
+++ b/src/service/orchestration-service.ts
@@ -1351,6 +1351,7 @@ export class OrchestrationService {
             stepAttempt: currentRework + 1,
             agent: step.agent,
             task: effectiveTask,
+            ticket: run.ticket,
             context_inputs: step.context_inputs,
             workspacePath,
             modelConfig,

--- a/src/service/runtime/codex-skill-manager.ts
+++ b/src/service/runtime/codex-skill-manager.ts
@@ -147,6 +147,17 @@ export class CodexSkillManager {
     };
   }
 
+  async resolveCatalogForRuntime(
+    workspacePath: string,
+    runtimeProvider: RuntimeProvider = "codex"
+  ): Promise<Record<string, SkillDefinition>> {
+    const skillsV2Enabled =
+      this.projectConfig.skills_v2_enabled ??
+      this.platformConfig.defaults.skills_v2_enabled ??
+      false;
+    return this.resolveCatalog(workspacePath, runtimeProvider, skillsV2Enabled);
+  }
+
   private resolveDestination(
     workspacePath: string,
     runtimeProvider: RuntimeProvider

--- a/src/service/runtime/dynamic-skill-resolver.ts
+++ b/src/service/runtime/dynamic-skill-resolver.ts
@@ -1,0 +1,166 @@
+import type {
+  AgentType,
+  DynamicSkillsConfig,
+  PlatformConfig,
+  ProjectConfig,
+  RuntimeProvider,
+  TicketDetails,
+} from "../../shared/types.js";
+import { CodexSkillManager } from "./codex-skill-manager.js";
+
+export interface RejectedDynamicSkill {
+  skill: string;
+  reason: string;
+}
+
+export interface DynamicSkillResolution {
+  enabled: boolean;
+  finalSkillNames: string[];
+  baseSkillNames: string[];
+  labelSkillNames: string[];
+  ignoredLabels: string[];
+  rejectedSkills: RejectedDynamicSkill[];
+  warnings: string[];
+  resolutionMode: "static" | "dynamic_label_merge";
+}
+
+const DEFAULT_LABEL_PREFIX = "sf:skill:";
+
+export class DynamicSkillResolver {
+  constructor(
+    private readonly platformConfig: PlatformConfig,
+    private readonly projectConfig: ProjectConfig,
+    private readonly skillManager: CodexSkillManager
+  ) {}
+
+  async resolveForRun(params: {
+    agent: AgentType;
+    runtimeProvider: RuntimeProvider;
+    ticket?: TicketDetails;
+    workspacePath: string;
+  }): Promise<DynamicSkillResolution> {
+    const base = this.skillManager.resolveForAgent(params.agent, params.runtimeProvider);
+    const config = this.projectConfig.dynamic_skills;
+    if (!this.isDynamicEnabled(config, params.ticket)) {
+      return {
+        enabled: base.enabled,
+        finalSkillNames: base.skillNames,
+        baseSkillNames: base.skillNames,
+        labelSkillNames: [],
+        ignoredLabels: [],
+        rejectedSkills: [],
+        warnings: [...base.warnings],
+        resolutionMode: "static",
+      };
+    }
+
+    const prefix = this.resolveLabelPrefix(config);
+    const labels = params.ticket?.labels ?? [];
+    const ignoredLabels: string[] = [];
+    const requestedSkills: string[] = [];
+
+    for (const rawLabel of labels) {
+      const normalized = String(rawLabel ?? "").trim();
+      if (!normalized) continue;
+      const lower = normalized.toLowerCase();
+      if (!lower.startsWith(prefix)) continue;
+      const skill = normalized.slice(prefix.length).trim();
+      if (!skill) {
+        ignoredLabels.push(normalized);
+        continue;
+      }
+      requestedSkills.push(skill);
+    }
+
+    const catalog = await this.skillManager.resolveCatalogForRuntime(
+      params.workspacePath,
+      params.runtimeProvider
+    );
+    const availableSkills = new Set(Object.keys(catalog));
+    const allowlist = this.normalizeSet(config?.allowlist);
+    const denylist = this.normalizeSet(config?.denylist);
+    const hasAgentScopedAllowlist = Object.keys(config?.agent_allowlist ?? {}).length > 0;
+    const agentAllowlist = this.normalizeSet(config?.agent_allowlist?.[params.agent]);
+
+    const accepted: string[] = [];
+    const rejectedSkills: RejectedDynamicSkill[] = [];
+
+    for (const skill of requestedSkills) {
+      const normalizedSkill = skill.trim();
+      const lowered = normalizedSkill.toLowerCase();
+      if (!normalizedSkill) continue;
+      if (allowlist.size > 0 && !allowlist.has(lowered)) {
+        rejectedSkills.push({ skill: normalizedSkill, reason: "not_in_allowlist" });
+        continue;
+      }
+      if (denylist.has(lowered)) {
+        rejectedSkills.push({ skill: normalizedSkill, reason: "in_denylist" });
+        continue;
+      }
+      if (hasAgentScopedAllowlist && !agentAllowlist.has(lowered)) {
+        rejectedSkills.push({ skill: normalizedSkill, reason: `not_allowed_for_agent:${params.agent}` });
+        continue;
+      }
+      if (!availableSkills.has(normalizedSkill)) {
+        rejectedSkills.push({ skill: normalizedSkill, reason: `not_defined_for_runtime:${params.runtimeProvider}` });
+        continue;
+      }
+      accepted.push(normalizedSkill);
+    }
+
+    const finalSkillNames = this.dedupe([...base.skillNames, ...accepted]);
+    const warnings = [...base.warnings];
+    for (const ignored of ignoredLabels) {
+      warnings.push(`Ignored dynamic skill label "${ignored}" because it did not declare a skill name`);
+    }
+    for (const rejected of rejectedSkills) {
+      warnings.push(`Rejected dynamic skill "${rejected.skill}": ${rejected.reason}`);
+    }
+
+    return {
+      enabled: base.enabled || finalSkillNames.length > 0,
+      finalSkillNames,
+      baseSkillNames: base.skillNames,
+      labelSkillNames: this.dedupe(accepted),
+      ignoredLabels,
+      rejectedSkills,
+      warnings,
+      resolutionMode: accepted.length > 0 || rejectedSkills.length > 0 || ignoredLabels.length > 0
+        ? "dynamic_label_merge"
+        : "static",
+    };
+  }
+
+  private isDynamicEnabled(
+    config: DynamicSkillsConfig | undefined,
+    ticket: TicketDetails | undefined
+  ): boolean {
+    if (!config?.enabled) return false;
+    if (config.allow_ticket_labels === false) return false;
+    if (!ticket) return false;
+    if ((config.label_source ?? "linear") === "linear" && ticket.source !== "linear") {
+      return false;
+    }
+    return true;
+  }
+
+  private resolveLabelPrefix(config: DynamicSkillsConfig | undefined): string {
+    return (config?.label_prefix ?? DEFAULT_LABEL_PREFIX).trim().toLowerCase();
+  }
+
+  private normalizeSet(values: string[] | undefined): Set<string> {
+    return new Set((values ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean));
+  }
+
+  private dedupe(values: string[]): string[] {
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const value of values) {
+      const normalized = value.trim();
+      if (!normalized || seen.has(normalized)) continue;
+      seen.add(normalized);
+      out.push(normalized);
+    }
+    return out;
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -210,6 +210,16 @@ export interface SkillGuardrails {
   mode?: "warn" | "error";
 }
 
+export interface DynamicSkillsConfig {
+  enabled?: boolean;
+  label_source?: "linear" | "all";
+  label_prefix?: string;
+  allow_ticket_labels?: boolean;
+  allowlist?: string[];
+  denylist?: string[];
+  agent_allowlist?: Record<string, string[]>;
+}
+
 export interface PlatformConfig {
   execution_backend?: ExecutionBackendName;
   defaults: {
@@ -301,6 +311,7 @@ export interface ProjectConfig {
   skill_assignments?: Record<string, string[]>;
   skill_sources?: SkillSource[];
   skill_guardrails?: SkillGuardrails;
+  dynamic_skills?: DynamicSkillsConfig;
   codex_skills_enabled?: boolean;
   codex_skill_catalog_overrides?: Record<string, CodexSkillDefinition>;
   codex_skills_overrides?: Record<string, string[]>;

--- a/tests/agent-runner.test.ts
+++ b/tests/agent-runner.test.ts
@@ -24,6 +24,7 @@ function makeRunConfig(overrides?: Partial<AgentRunConfig>): AgentRunConfig {
     stepAttempt: overrides?.stepAttempt ?? 1,
     agent: overrides?.agent ?? "developer",
     task: overrides?.task ?? "Implement the feature",
+    ticket: overrides?.ticket,
     context_inputs: overrides?.context_inputs ?? [{ type: "ticket" }],
     workspacePath: overrides?.workspacePath ?? "/tmp/test-workspace",
     modelConfig: overrides?.modelConfig ?? makeModelConfig(),
@@ -610,6 +611,167 @@ describe("AgentRunner", () => {
     const agentsMd = await fs.readFile(path.join(workspacePath, "AGENTS.md"), "utf-8");
     expect(agentsMd).toContain("## Runtime Skills");
     expect(agentsMd).toContain("web-design-guidelines");
+  });
+
+  it("prepareWorkspace merges base and label-derived skills into runtime metadata", async () => {
+    const workspacePath = path.join(tmpDir, "workspace-dynamic-codex-skill");
+    await fs.mkdir(workspacePath, { recursive: true });
+
+    const skillRoot = path.join(tmpDir, "skills-dynamic");
+    const baseSkill = path.join(skillRoot, "develop-web-game");
+    const labelSkill = path.join(skillRoot, "phaser-arcade-platformer");
+    await fs.mkdir(baseSkill, { recursive: true });
+    await fs.mkdir(labelSkill, { recursive: true });
+    await fs.writeFile(path.join(baseSkill, "SKILL.md"), "# develop-web-game", "utf-8");
+    await fs.writeFile(path.join(labelSkill, "SKILL.md"), "# phaser-arcade-platformer", "utf-8");
+
+    const runner = new AgentRunner(
+      makePlatformConfig({
+        defaults: {
+          ...makePlatformConfig().defaults,
+          skills_v2_enabled: true,
+          skills_enabled: true,
+          skill_catalog: {
+            "develop-web-game": { path: baseSkill },
+            "phaser-arcade-platformer": { path: labelSkill },
+          },
+          skill_assignments_per_agent: {
+            developer: ["develop-web-game"],
+          },
+        },
+      }),
+      makeProjectConfig({
+        skills_v2_enabled: true,
+        skills_enabled: true,
+        dynamic_skills: {
+          enabled: true,
+          allowlist: ["develop-web-game", "phaser-arcade-platformer"],
+          agent_allowlist: {
+            developer: ["develop-web-game", "phaser-arcade-platformer"],
+          },
+        },
+      })
+    );
+
+    const prep = await (runner as any).prepareWorkspace(
+      makeRunConfig({
+        agent: "developer",
+        workspacePath,
+        ticket: {
+          id: "SPR-42",
+          source: "linear",
+          title: "Tune movement",
+          description: "Apply game feel polish",
+          labels: ["sf:skill:phaser-arcade-platformer"],
+          priority: "p2",
+          acceptance_criteria: [],
+          linked_tickets: [],
+          comments: [],
+          author: "test-user",
+          raw: {},
+        },
+      }),
+      { provider: "codex", mode: "local_process" }
+    );
+
+    expect(prep.codexSkillNames).toEqual([
+      "develop-web-game",
+      "phaser-arcade-platformer",
+    ]);
+    expect(prep.baseSkillNames).toEqual(["develop-web-game"]);
+    expect(prep.labelSkillNames).toEqual(["phaser-arcade-platformer"]);
+    expect(prep.skillResolutionMode).toBe("dynamic_label_merge");
+  });
+
+  it("run preserves rejected label-skill warnings in runtime metadata even when nothing is staged", async () => {
+    delete process.env.SPRINTFOUNDRY_USE_CONTAINERS;
+    const runStepSpy = vi.spyOn(CodexRuntime.prototype, "runStep").mockResolvedValue({
+      tokens_used: 111,
+      runtime_id: "codex-runtime-warn-only",
+      usage: { total_tokens: 111 },
+      runtime_metadata: {
+        schema_version: 1,
+        runtime: {
+          provider: "codex",
+          mode: "local_process",
+          runtime_id: "codex-runtime-warn-only",
+          step_attempt: 1,
+        },
+      },
+    } as any);
+
+    const skillRoot = path.join(tmpDir, "skills-dynamic-warn-only");
+    const qaSkill = path.join(skillRoot, "playwright");
+    await fs.mkdir(qaSkill, { recursive: true });
+    await fs.writeFile(path.join(qaSkill, "SKILL.md"), "# playwright", "utf-8");
+
+    const runner = new AgentRunner(
+      makePlatformConfig({
+        defaults: {
+          ...makePlatformConfig().defaults,
+          skills_v2_enabled: true,
+          skills_enabled: true,
+          skill_catalog: {
+            playwright: { path: qaSkill },
+          },
+        },
+      }),
+      makeProjectConfig({
+        runtime_overrides: {
+          developer: { provider: "codex", mode: "local_process" },
+        },
+        skills_v2_enabled: true,
+        skills_enabled: true,
+        dynamic_skills: {
+          enabled: true,
+          allowlist: ["playwright"],
+          agent_allowlist: {
+            qa: ["playwright"],
+          },
+        },
+      })
+    );
+    (runner as any).readAgentResult = vi.fn().mockResolvedValue(makeResult());
+    const workspacePath = path.join(tmpDir, "workspace-dynamic-warn-only");
+    await fs.mkdir(workspacePath, { recursive: true });
+
+    const result = await runner.run(
+      makeRunConfig({
+        agent: "developer",
+        workspacePath,
+        ticket: {
+          id: "SPR-77",
+          source: "linear",
+          title: "Request unsupported skill",
+          description: "Skill label should be rejected for developer",
+          labels: ["sf:skill:playwright"],
+          priority: "p2",
+          acceptance_criteria: [],
+          linked_tickets: [],
+          comments: [],
+          author: "test-user",
+          raw: {},
+        },
+      })
+    );
+
+    expect(runStepSpy).toHaveBeenCalledTimes(1);
+    expect(runStepSpy.mock.calls[0][0].codexSkillNames).toBeUndefined();
+    expect((result.runtime_metadata as any)?.provider_metadata?.skills).toMatchObject({
+      names: [],
+      base_skills: [],
+      label_skills: [],
+      resolution_mode: "dynamic_label_merge",
+      provider: "codex",
+      rejected_skills: [
+        { skill: "playwright", reason: "not_allowed_for_agent:developer" },
+      ],
+    });
+    expect(
+      ((result.runtime_metadata as any)?.provider_metadata?.skills?.warnings ?? []).some(
+        (warning: string) => warning.includes("playwright")
+      )
+    ).toBe(true);
   });
 
   it("project runtime override takes precedence over platform runtime defaults", async () => {

--- a/tests/dynamic-skill-resolver.test.ts
+++ b/tests/dynamic-skill-resolver.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "fs/promises";
+import * as os from "os";
+import * as path from "path";
+import type { TicketDetails } from "../src/shared/types.js";
+import { CodexSkillManager } from "../src/service/runtime/codex-skill-manager.js";
+import { DynamicSkillResolver } from "../src/service/runtime/dynamic-skill-resolver.js";
+import { makePlatformConfig, makeProjectConfig } from "./fixtures/configs.js";
+
+function makeTicket(overrides?: Partial<TicketDetails>): TicketDetails {
+  return {
+    id: overrides?.id ?? "SPR-100",
+    source: overrides?.source ?? "linear",
+    title: overrides?.title ?? "Add movement feel polish",
+    description: overrides?.description ?? "Tune movement and visuals",
+    labels: overrides?.labels ?? [],
+    priority: overrides?.priority ?? "p2",
+    acceptance_criteria: overrides?.acceptance_criteria ?? [],
+    linked_tickets: overrides?.linked_tickets ?? [],
+    comments: overrides?.comments ?? [],
+    author: overrides?.author ?? "test-user",
+    raw: overrides?.raw ?? {},
+    identifier: overrides?.identifier,
+    url: overrides?.url,
+    state: overrides?.state,
+    state_id: overrides?.state_id,
+    state_type: overrides?.state_type,
+    team_id: overrides?.team_id,
+    team_key: overrides?.team_key,
+    assignee: overrides?.assignee,
+  };
+}
+
+describe("DynamicSkillResolver", () => {
+  it("adds allowlisted skills from explicit linear labels", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dynamic-skills-"));
+    const workspace = path.join(tmpDir, "workspace");
+    const skillSource = path.join(tmpDir, "skills");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(path.join(skillSource, "develop-web-game"), { recursive: true });
+    await fs.mkdir(path.join(skillSource, "phaser-arcade-platformer"), { recursive: true });
+    await fs.writeFile(path.join(skillSource, "develop-web-game", "SKILL.md"), "# develop-web-game", "utf-8");
+    await fs.writeFile(path.join(skillSource, "phaser-arcade-platformer", "SKILL.md"), "# phaser", "utf-8");
+
+    const platform = makePlatformConfig({
+      defaults: {
+        ...makePlatformConfig().defaults,
+        skills_v2_enabled: true,
+        skills_enabled: true,
+        skill_catalog: {
+          "develop-web-game": { path: path.join(skillSource, "develop-web-game") },
+          "phaser-arcade-platformer": { path: path.join(skillSource, "phaser-arcade-platformer") },
+        },
+        skill_assignments_per_agent: {
+          developer: ["develop-web-game"],
+        },
+      },
+    });
+    const project = makeProjectConfig({
+      skills_v2_enabled: true,
+      skills_enabled: true,
+      dynamic_skills: {
+        enabled: true,
+        label_prefix: "sf:skill:",
+        allowlist: ["develop-web-game", "phaser-arcade-platformer"],
+        agent_allowlist: {
+          developer: ["develop-web-game", "phaser-arcade-platformer"],
+        },
+      },
+    });
+    const resolver = new DynamicSkillResolver(
+      platform,
+      project,
+      new CodexSkillManager(platform, project, process.cwd())
+    );
+
+    const result = await resolver.resolveForRun({
+      agent: "developer",
+      runtimeProvider: "claude-code",
+      workspacePath: workspace,
+      ticket: makeTicket({
+        labels: ["movement", "sf:skill:phaser-arcade-platformer"],
+      }),
+    });
+
+    expect(result.finalSkillNames).toEqual(["develop-web-game", "phaser-arcade-platformer"]);
+    expect(result.baseSkillNames).toEqual(["develop-web-game"]);
+    expect(result.labelSkillNames).toEqual(["phaser-arcade-platformer"]);
+    expect(result.rejectedSkills).toEqual([]);
+    expect(result.resolutionMode).toBe("dynamic_label_merge");
+  });
+
+  it("rejects unknown or disallowed label skills with warnings", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dynamic-skills-reject-"));
+    const workspace = path.join(tmpDir, "workspace");
+    const skillSource = path.join(tmpDir, "skills");
+    await fs.mkdir(workspace, { recursive: true });
+    await fs.mkdir(path.join(skillSource, "playwright"), { recursive: true });
+    await fs.writeFile(path.join(skillSource, "playwright", "SKILL.md"), "# playwright", "utf-8");
+
+    const platform = makePlatformConfig({
+      defaults: {
+        ...makePlatformConfig().defaults,
+        skills_v2_enabled: true,
+        skills_enabled: true,
+        skill_catalog: {
+          playwright: { path: path.join(skillSource, "playwright") },
+        },
+      },
+    });
+    const project = makeProjectConfig({
+      skills_v2_enabled: true,
+      skills_enabled: true,
+      dynamic_skills: {
+        enabled: true,
+        allowlist: ["playwright"],
+        agent_allowlist: {
+          qa: ["playwright"],
+        },
+      },
+    });
+    const resolver = new DynamicSkillResolver(
+      platform,
+      project,
+      new CodexSkillManager(platform, project, process.cwd())
+    );
+
+    const result = await resolver.resolveForRun({
+      agent: "developer",
+      runtimeProvider: "claude-code",
+      workspacePath: workspace,
+      ticket: makeTicket({
+        labels: [
+          "sf:skill:playwright",
+          "sf:skill:missing-skill",
+          "sf:skill:",
+        ],
+      }),
+    });
+
+    expect(result.finalSkillNames).toEqual([]);
+    expect(result.labelSkillNames).toEqual([]);
+    expect(result.ignoredLabels).toEqual(["sf:skill:"]);
+    expect(result.rejectedSkills).toEqual([
+      { skill: "playwright", reason: "not_allowed_for_agent:developer" },
+      { skill: "missing-skill", reason: "not_in_allowlist" },
+    ]);
+    expect(result.warnings.some((item) => item.includes("playwright"))).toBe(true);
+  });
+
+  it("ignores labels from non-linear tickets when label_source is linear", async () => {
+    const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "dynamic-skills-source-"));
+    const workspace = path.join(tmpDir, "workspace");
+    await fs.mkdir(workspace, { recursive: true });
+
+    const platform = makePlatformConfig({
+      defaults: {
+        ...makePlatformConfig().defaults,
+        skills_v2_enabled: true,
+        skills_enabled: true,
+      },
+    });
+    const project = makeProjectConfig({
+      skills_v2_enabled: true,
+      skills_enabled: true,
+      dynamic_skills: {
+        enabled: true,
+        label_source: "linear",
+        allowlist: ["playwright"],
+      },
+    });
+    const resolver = new DynamicSkillResolver(
+      platform,
+      project,
+      new CodexSkillManager(platform, project, process.cwd())
+    );
+
+    const result = await resolver.resolveForRun({
+      agent: "qa",
+      runtimeProvider: "codex",
+      workspacePath: workspace,
+      ticket: makeTicket({
+        source: "github",
+        labels: ["sf:skill:playwright"],
+      }),
+    });
+
+    expect(result.resolutionMode).toBe("static");
+    expect(result.finalSkillNames).toEqual([]);
+    expect(result.labelSkillNames).toEqual([]);
+  });
+});

--- a/tests/fixtures/configs.ts
+++ b/tests/fixtures/configs.ts
@@ -98,6 +98,16 @@ export function makeProjectConfig(
     execution_backend_override: overrides?.execution_backend_override,
     runtime_overrides: overrides?.runtime_overrides,
     planner_runtime_override: overrides?.planner_runtime_override,
+    skills_v2_enabled: overrides?.skills_v2_enabled,
+    skills_enabled: overrides?.skills_enabled,
+    skill_catalog_overrides: overrides?.skill_catalog_overrides,
+    skill_assignments: overrides?.skill_assignments,
+    skill_sources: overrides?.skill_sources,
+    skill_guardrails: overrides?.skill_guardrails,
+    dynamic_skills: overrides?.dynamic_skills,
+    codex_skills_enabled: overrides?.codex_skills_enabled,
+    codex_skill_catalog_overrides: overrides?.codex_skill_catalog_overrides,
+    codex_skills_overrides: overrides?.codex_skills_overrides,
   };
 }
 

--- a/tests/preflight.test.ts
+++ b/tests/preflight.test.ts
@@ -79,6 +79,7 @@ describe("runPreflight", () => {
   it("skips host-only kubernetes checks inside a hosted whole-run sandbox", async () => {
     const platform = makePlatformConfig({
       defaults: {
+        ...makePlatformConfig().defaults,
         runtime_per_agent: {
           developer: { provider: "codex", mode: "local_sdk" },
         },


### PR DESCRIPTION
## Summary
- add `dynamic_skills` project config for additive skill injection from explicit ticket labels like `sf:skill:<name>`
- resolve label-derived skills at agent runtime with allowlist, denylist, and per-agent allowlist enforcement
- surface base skills, label skills, ignored labels, rejected skills, and resolution mode in runtime metadata and document the new config

## Testing
- `pnpm typecheck`
- `pnpm test -- tests/agent-runner.test.ts tests/dynamic-skill-resolver.test.ts tests/codex-skill-manager.test.ts`
- `$HOME/.codex/skills/sprintfoundry-testing/scripts/run_sprintfoundry_test_matrix.sh --repo /Users/trivedi/Documents/Projects/SprintFoundry-linear-label-skills --profile full`
- kind pod validation in `sf-skill-validate/sf-skill-tests`: `pnpm install --frozen-lockfile && pnpm typecheck && pnpm test -- tests/dynamic-skill-resolver.test.ts tests/codex-skill-manager.test.ts tests/agent-runner.test.ts tests/orchestration-service.test.ts`
